### PR TITLE
feat/PokebaseVaiDeBase

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 .ipynb_checkpoints
 .__pycache__
 Imagens
+
+**/data

--- a/scrappers/bulbapedia.py
+++ b/scrappers/bulbapedia.py
@@ -4,7 +4,7 @@ Site base: https://bulbapedia.bulbagarden.net/wiki/Bulbapedia
 
 from typing import List
 import requests
-import pokebase as pb
+from pokedex import pokedex
 from hashlib import md5
 
 
@@ -54,7 +54,7 @@ def getImagesURLbyId(id: int) -> List[str]:
     """
     print(f"> Pushando #{id} de bulbagarden.com")
 
-    pokemon = pb.pokemon(id)
+    pokemon = pokedex[id]
 
     url = "https://archives.bulbagarden.net/w/api.php"
     params = {

--- a/scrappers/main.py
+++ b/scrappers/main.py
@@ -2,7 +2,6 @@
 
 from typing import List
 from pathlib import Path
-import pokebase as pb
 from functools import partial
 from multiprocessing import Pool
 
@@ -15,6 +14,7 @@ import serebii
 # import zerochan
 
 import acess
+from pokedex import pokedex
 
 _NUMBER_POOLS = 6
 
@@ -70,7 +70,7 @@ def getAllImagesAndSaveById(id: int, base_path: Path) -> List[Path]:
     Lista de urls encontradas
 
     """
-    pokemon = pb.pokemon(id)
+    pokemon = pokedex[id]
     imgsURL = getAllImagesURLbyId(id)
     imgs = acess.downloadImgs(imgsURL)
     path = base_path / pokemon.name

--- a/scrappers/pokeCards.py
+++ b/scrappers/pokeCards.py
@@ -6,7 +6,7 @@ from typing import List
 import requests
 import re
 from bs4 import BeautifulSoup
-import pokebase as pb
+from pokedex import pokedex
 
 filterCards = "basic-pokemon=on&stage-1-pokemon=on&stage-2-pokemon=on&level-up-pokemon=on&ex-pokemon=on&mega-ex=on&special-pokemon=on&pokemon-legend=on&restored-pokemon=on&break=on&pokemon-gx=on&pokemon-v=on&pokemon-vmax=on"
 
@@ -30,7 +30,7 @@ def getImagesURLbyId(id: int) -> List[str]:
     """
 
     print(f"> Pushando #{id} de pokemon.com/us/pokemon-tcg/pokemon-cards")
-    pokemon = pb.pokemon(id)
+    pokemon = pokedex[id]
 
     def url(page=1):
         return f"https://www.pokemon.com/us/pokemon-tcg/pokemon-cards/{page}?cardName={pokemon.name}&{filterCards}"

--- a/scrappers/pokedex.py
+++ b/scrappers/pokedex.py
@@ -1,0 +1,65 @@
+"""
+    Ao importar roda _fillPokedex(),
+    prenchendo a variavel local pokedex com um dicionario de pokemons
+"""
+
+import requests
+
+pokedex = None
+
+
+class Pokemon:
+    """
+    Descrição
+    --------
+    Classe basica para agrupar dados de pokemons
+
+    Atributos
+    --------
+    id: int
+    Numero da pokedex do pokemon
+
+    name: str
+    Nome do pokemon
+    """
+    id: int = None
+    name: str = None
+
+    def __init__(self, id: str, name: str):
+        self.id = id
+        self.name = name
+
+    def __str__(self):
+        return f"#{self.id:03}-{self.name}"
+
+    def __repr__(self):
+        return f"Pokemon({self.id},{self.name})"
+
+
+def _fillPokedex():
+    """
+        Prenche a variavel global com os pokemons oriundos de um csv
+    """
+    global pokedex
+    if pokedex is not None:
+        return
+
+    pokedex = dict()
+
+    response = requests.get(
+        "https://raw.githubusercontent.com/veekun/pokedex/master/pokedex/data/csv/pokemon.csv")
+
+    # Break in lines and remove header
+    pokedexData = response.text.split('\n')[1:]
+    for pokedexLine in pokedexData:
+        if pokedexLine.strip(' ,') == '':
+            continue
+
+        [id, name, *_] = pokedexLine.split(',')
+        id = int(id)  # Grr odeio a tipagem fraca de python
+        pokemon = Pokemon(id, name)
+        pokedex[id] = pokemon
+        pokedex[name] = pokemon
+
+
+_fillPokedex()

--- a/scrappers/pokemondb.py
+++ b/scrappers/pokemondb.py
@@ -6,7 +6,7 @@ from typing import List
 import requests
 import re
 from bs4 import BeautifulSoup
-import pokebase as pb
+from pokedex import pokedex
 
 
 def getImagesURLbyId(id: int) -> List[str]:
@@ -29,7 +29,7 @@ def getImagesURLbyId(id: int) -> List[str]:
 
     print(f"> Pushando #{id} de pokemondb.net")
 
-    pokemon = pb.pokemon(id)
+    pokemon = pokedex[id]
     url = f"https://pokemondb.net/sprites/{pokemon.name}"
 
     response = requests.get(url)

--- a/scrappers/requirements.txt
+++ b/scrappers/requirements.txt
@@ -1,2 +1,3 @@
 requests
-bs4
+beautifulsoup4
+filetype

--- a/scrappers/requirements.txt
+++ b/scrappers/requirements.txt
@@ -1,4 +1,2 @@
 requests
-grequests
-pokebase
 bs4

--- a/scrappers/zerochan.py
+++ b/scrappers/zerochan.py
@@ -4,7 +4,7 @@ Site base: https://www.zerochan.net/pikachu?p=2
 
 from typing import List
 import requests
-import pokebase as pb
+from pokedex import pokedex
 from bs4 import BeautifulSoup
 
 
@@ -28,7 +28,7 @@ def getImagesURLbyId(id: int) -> List[str]:
 
     print(f"> Pushando #{id} de zerochan.com")
 
-    pokemon = pb.pokemon(id)
+    pokemon = pokedex[id]
 
     url = f"https://www.zerochan.net/{pokemon.name}"
 


### PR DESCRIPTION
O pokebase estava se tornando o gargalo para o numero de requisições
embora fosse usados apenas para mapear o id para o nome do pokemon por baixo dos panos ele fazia uma requisição para uma api, que nos dava timeout

Substituindo por uma implementaão local (usando um csv da net) conseguimos aumentar o numero de requisições em paralelo sem medo
